### PR TITLE
Fix Enum handling

### DIFF
--- a/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/AvroConverter.scala
+++ b/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/AvroConverter.scala
@@ -257,7 +257,7 @@ private[elitzur] class AvroEnumConverter[T <: enumeratum.EnumEntry: Enum] extend
   override def fromAvro(v: Any, schema: Schema, doc: Option[String]): T =
     implicitly[Enum[T]].withName(v.toString)
 
-  override def toAvro(v: T, schema: Schema): Any = new GenericData.EnumSymbol(schema, v.toString)
+  override def toAvro(v: T, schema: Schema): Any = new GenericData.EnumSymbol(schema, v.entryName)
 
   override def toAvroDefault(v: T, defaultGenericContainer: GenericContainer): Any =
     v.asInstanceOf[Any]

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroConverterTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroConverterTest.scala
@@ -3,6 +3,10 @@ package com.spotify.elitzur
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import enumeratum.EnumEntry.Snakecase
+import enumeratum._
+import org.apache.avro.Schema
+
 object AvroClassConverterTest {
   case class TestTypes(userAge: Long,
                        userFloat: Float,
@@ -11,9 +15,35 @@ object AvroClassConverterTest {
                        inner: Inner)
 
   case class Inner(userId: String, countryCode: String, playCount: Long)
+
+  sealed trait EnumValue extends EnumEntry with Snakecase
+  object EnumValue extends Enum[EnumValue] {
+    val values = findValues
+    case object SnakeCaseAaa extends EnumValue
+    case object SnakeCaseBbb extends EnumValue
+    case object SnakeCaseCcc extends EnumValue
+  }
+  case class TestEnum(testEnum: EnumValue, optTestEnum: Option[EnumValue])
 }
 
 class AvroConverterTest extends AnyFlatSpec with Matchers {
+
+  it should "round-trip enumeratum enums" in {
+    import AvroClassConverterTest._
+    import com.spotify.elitzur.converters.avro._
+    import com.spotify.elitzur.schemas.TestAvroEnum
+
+    val converter: AvroConverter[TestEnum] = implicitly
+    val schema: Schema = TestAvroEnum.getClassSchema
+
+    val a: TestEnum = TestEnum(EnumValue.SnakeCaseBbb, Some(EnumValue.SnakeCaseCcc))
+    val b: TestEnum = converter.fromAvro(converter.toAvro(a, schema), schema)
+    assert(a == b)
+
+    val c: TestEnum = TestEnum(EnumValue.SnakeCaseAaa, None)
+    val d: TestEnum = converter.fromAvro(converter.toAvro(c, schema), schema)
+    assert(c == d)
+  }
 
   it should "work on nested optional records w/toAvro" in {
     import AvroClassConverterTest._

--- a/elitzur-schemas/src/main/avro/TestAvroEnum.avsc
+++ b/elitzur-schemas/src/main/avro/TestAvroEnum.avsc
@@ -1,0 +1,20 @@
+{
+  "name": "TestAvroEnum",
+  "namespace": "com.spotify.elitzur.schemas",
+  "type": "record",
+  "fields": [
+    {
+      "name": "testEnum",
+      "type": {
+        "type": "enum",
+        "name": "TestAvroEnumValue",
+        "symbols": ["snake_case_aaa", "snake_case_bbb", "snake_case_ccc"]
+      }
+    },
+    {
+      "name": "optTestEnum",
+      "type": ["null", "com.spotify.elitzur.schemas.TestAvroEnumValue"],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes enumeratum enum handling to use `entryName` rather than `toString` per [the docs](https://github.com/lloydmeta/enumeratum#enum-1).

When converting from a `case object`, `toString` will give you the scala name, e.g. `SnakeCaseAaa` where the enum expects `snake_case_aaa` and a comparison against the schema enum values will fail.

`entryName` gives you the actual enum entry name instead, e.g. `snake_case_aaa`
