### PR TITLE
Fix optional field handling

### DIFF
--- a/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/AvroElitzurConversionUtils.scala
+++ b/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/AvroElitzurConversionUtils.scala
@@ -57,17 +57,6 @@ object AvroElitzurConversionUtils {
       (Schema.Type.UNION.equals(schema.getType) &&
         schema.getTypes.asScala.map(_.getType).contains(Schema.Type.RECORD))
 
-
-  private[elitzur] def getNestedRecordSchema(schema: Schema): Schema =
-    schema match {
-      case x if Schema.Type.RECORD.equals(x.getType) => x
-      case x if isAvroRecordType(x) =>
-        x.getTypes.asScala.filterNot(s => Schema.Type.NULL.equals(s.getType)).headOption
-          .getOrElse(x)
-      case _ => throw new RuntimeException("Not a record schema. This shouldn't happen.")
-    }
-
-
   private[elitzur] def isAvroArrayType(schema: Schema): Boolean =
     Schema.Type.ARRAY.equals(schema.getType) ||
       (Schema.Type.UNION.equals(schema.getType) && schema.getTypes.contains(Schema.Type.ARRAY))

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroConverterTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroConverterTest.scala
@@ -3,6 +3,15 @@ package com.spotify.elitzur
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.ByteBuffer
+import org.apache.avro.generic.GenericData
+import org.apache.avro.specific.SpecificData
+import org.apache.avro.message.{BinaryMessageEncoder, BinaryMessageDecoder}
+import com.spotify.elitzur.converters.avro.AvroConverter
+import enumeratum.EnumEntry.Snakecase
+import enumeratum._
+import org.apache.avro.Schema
+
 object AvroClassConverterTest {
   case class TestTypes(userAge: Long,
                        userFloat: Float,
@@ -11,9 +20,37 @@ object AvroClassConverterTest {
                        inner: Inner)
 
   case class Inner(userId: String, countryCode: String, playCount: Long)
+
+  sealed trait EnumValue extends EnumEntry with Snakecase
+  object EnumValue extends Enum[EnumValue] {
+    val values = findValues
+    case object SnakeCaseAaa extends EnumValue
+    case object SnakeCaseBbb extends EnumValue
+    case object SnakeCaseCcc extends EnumValue
+  }
+  case class TestEnum(testEnum: EnumValue, optTestEnum: Option[EnumValue])
 }
 
 class AvroConverterTest extends AnyFlatSpec with Matchers {
+
+  it should "round-trip via a generic record" in {
+    import AvroClassConverterTest._
+    import com.spotify.elitzur.converters.avro._
+    import com.spotify.elitzur.schemas.TestAvroEnum
+
+    val schema: Schema = TestAvroEnum.getClassSchema
+    val converter: AvroConverter[TestEnum] = implicitly
+    val decoder = new BinaryMessageDecoder[TestAvroEnum](new SpecificData(), schema)
+
+    val a: TestEnum = TestEnum(EnumValue.SnakeCaseBbb, Some(EnumValue.SnakeCaseCcc))
+    val rec: GenericData.Record = converter.toAvro(a, schema).asInstanceOf[GenericData.Record]
+    val encoder = new BinaryMessageEncoder[GenericData.Record](new GenericData(), schema)
+    val bytes: ByteBuffer =  encoder.encode(rec)
+    val converted: TestAvroEnum = decoder.decode(bytes)
+
+    val b: TestEnum = converter.fromAvro(converted, schema)
+    assert(a == b)
+  }
 
   it should "work on nested optional records w/toAvro" in {
     import AvroClassConverterTest._

--- a/elitzur-schemas/src/main/avro/TestAvroEnum.avsc
+++ b/elitzur-schemas/src/main/avro/TestAvroEnum.avsc
@@ -1,0 +1,20 @@
+{
+  "name": "TestAvroEnum",
+  "namespace": "com.spotify.elitzur.schemas",
+  "type": "record",
+  "fields": [
+    {
+      "name": "testEnum",
+      "type": {
+        "type": "enum",
+        "name": "TestAvroEnumValue",
+        "symbols": ["snake_case_aaa", "snake_case_bbb", "snake_case_ccc"]
+      }
+    },
+    {
+      "name": "optTestEnum",
+      "type": ["null", "com.spotify.elitzur.schemas.TestAvroEnumValue"],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes optional field handling in `AvroConverter`.

This is a follow-up to #24 and #5 which seems to be a special-case of the issue I was having here, namely that `Option[MyEnum]` was failing to be converted. Deep down in the generic record internals, a match is done against the datum schema type and the expected schema types and carrying over the full `UNION["null", ...]` schema meant that this check failed.

I reverted some of the changes from #5 since they were made unnecessary by unwrapping the schema in the `OptionConverter` and `AvroOptionConverter` classes.

The avro test class and the change to `AvroEnumConverter` are the same as in #24 and can be taken from either PR. 