### PR TITLE
Update .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,8 +1,6 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx8G
+-Xmx6G
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
--XX:-UseGCOverheadLimit
--XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC
+-XX:+UseParallelGC

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,6 +1,0 @@
--J-Xmx6G
--J-Xms2G
--J-Xss1M
--J-XX:MaxMetaspaceSize=1G
--J-XX:+CMSClassUnloadingEnabled
--J-XX:ReservedCodeCacheSize=128m


### PR DESCRIPTION
Hello,

Just notice that you are using both .jvmopts and .sbtops ... You can just go with one. I left abd simplified `.jvmopts` because it works well with bloop and sbt.

Also changed the GC with JDK11 in mind.