### PR TITLE
Make Owner public

### DIFF
--- a/elitzur-core/src/main/scala/com/spotify/elitzur/types/Owner.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/types/Owner.scala
@@ -16,6 +16,6 @@
  */
 package com.spotify.elitzur.types
 
-private[elitzur] trait Owner {
+trait Owner {
   def name: String
 }


### PR DESCRIPTION
Make this public to allow easier definitions of validation types.  Users can now define them in their own packages.