### PR TITLE
Allow user to change default ValidationFieldConfig

### DIFF
--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
@@ -55,8 +55,7 @@ final private[elitzur] case class DerivedValidator[T] private(caseClass: CaseCla
             val v = p.typeclass.validateRecord(Unvalidated(deref))
             val validationType = p.typeclass.asInstanceOf[FieldValidator[_]].validationType
 
-            val c: ValidationFieldConfig = config.m
-              .getOrElse(name, DefaultFieldConfig).asInstanceOf[ValidationFieldConfig]
+            val c = config.fieldConfig(name)
             if (v.isValid) {
               if (c != NoCounter) {
                 reporter.reportValid(
@@ -64,8 +63,7 @@ final private[elitzur] case class DerivedValidator[T] private(caseClass: CaseCla
                   name,
                   validationType)
               }
-            }
-            else if (v.isInvalid) {
+            } else if (v.isInvalid) {
               if (c == ThrowException) {
                 throw new DataInvalidException(
                   s"Invalid value ${v.forceGet.toString} found for field $path${p.label}")

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/ValidationConfig.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/ValidationConfig.scala
@@ -16,24 +16,27 @@
  */
 package com.spotify.elitzur.validators
 
-trait ValidationConfig
-trait ValidationFieldConfig extends ValidationConfig
+trait ValidationConfig extends Serializable
 
 trait ValidationRecordConfig extends ValidationConfig {
-  def m: Map[String, ValidationConfig]
+  def fieldConfig(name: String): ValidationFieldConfig
 }
 
-case class MapConfig(m: Map[String, ValidationConfig]) extends ValidationRecordConfig
 
-case object DefaultRecordConfig extends ValidationRecordConfig {
-  override def m: Map[String, ValidationConfig] = Map()
+class MapConfig(
+  m: Map[String, ValidationFieldConfig],
+  default: ValidationFieldConfig = DefaultFieldConfig
+) extends ValidationRecordConfig {
+  override def fieldConfig(name: String): ValidationFieldConfig = m.getOrElse(name, default)
 }
+
+case object DefaultRecordConfig extends MapConfig(Map())
 
 object ValidationRecordConfig {
-  def apply(s: (String, ValidationConfig)*): ValidationRecordConfig =
-    MapConfig(Map(s:_*))
+  def apply(s: (String, ValidationFieldConfig)*): ValidationRecordConfig = new MapConfig(Map(s:_*))
 }
 
+sealed trait ValidationFieldConfig extends ValidationConfig
 case object ThrowException extends ValidationFieldConfig
 case object NoCounter extends ValidationFieldConfig
 case object DefaultFieldConfig extends ValidationFieldConfig


### PR DESCRIPTION
When using `elitzur`, we would like to have `ThrowException` as default behavior and only override special fields with `DefaultFieldConfig`.

This is currently not possible since the default case is hard-coded in the `DerivedValidator`.

This PR aims to give more flexibility to users by choosing the default validation configuration.