### PR TITLE
Split out core validation loop from derived validator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val releaseSettings = Seq(
     Developer(id="anne-decusatis", name="Anne DeCusatis", email="anned@spotify.com", url=url("https://twitter.com/precisememory")),
     Developer(id="catherinejelder", name="Catherine Elder", email="siege@spotify.com", url=url("https://twitter.com/siegeelder")),
     Developer(id="idreeskhan", name="Idrees Khan", email="me@idrees.xyz", url=url("https://twitter.com/idreesxkhan")),
-    Developer(id="jackdingilian", name="Jack Dingilian", email="jackd@spotify.com", url=url("")),
+//    Developer(id="jackdingilian", name="Jack Dingilian", email="jackd@spotify.com", url=url("")),
     // TODO add the rest of the team
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val releaseSettings = Seq(
     Developer(id="anne-decusatis", name="Anne DeCusatis", email="anned@spotify.com", url=url("https://twitter.com/precisememory")),
     Developer(id="catherinejelder", name="Catherine Elder", email="siege@spotify.com", url=url("https://twitter.com/siegeelder")),
     Developer(id="idreeskhan", name="Idrees Khan", email="me@idrees.xyz", url=url("https://twitter.com/idreesxkhan")),
-//    Developer(id="jackdingilian", name="Jack Dingilian", email="jackd@spotify.com", url=url("")),
+    Developer(id="jackdingilian", name="Jack Dingilian", email="jackd@spotify.com", url=url("https://github.com/jackdingilian")),
     // TODO add the rest of the team
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,8 @@ lazy val releaseSettings = Seq(
     // current maintainers
     Developer(id="anne-decusatis", name="Anne DeCusatis", email="anned@spotify.com", url=url("https://twitter.com/precisememory")),
     Developer(id="catherinejelder", name="Catherine Elder", email="siege@spotify.com", url=url("https://twitter.com/siegeelder")),
-    Developer(id="idreeskhan", name="Idrees Khan", email="me@idreeskhan.com", url=url("https://twitter.com/idreesxkhan")),
+    Developer(id="idreeskhan", name="Idrees Khan", email="me@idrees.xyz", url=url("https://twitter.com/idreesxkhan")),
+    Developer(id="jackdingilian", name="Jack Dingilian", email="jackd@spotify.com", url=url("")),
     // TODO add the rest of the team
   )
 )

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
@@ -16,104 +16,37 @@
  */
 package com.spotify.elitzur.validators
 
-import java.lang.{StringBuilder => JStringBuilder}
-
-import com.spotify.elitzur.{DataInvalidException, MetricsReporter}
+import com.spotify.elitzur.MetricsReporter
 import magnolia._
 
-import scala.collection.compat.immutable.ArraySeq
 
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
 final private[elitzur] case class DerivedValidator[T] private(caseClass: CaseClass[Validator, T])
                                                              (implicit reporter: MetricsReporter)
   extends Validator[T] {
-  //scalastyle:off method.length cyclomatic.complexity
   override def validateRecord(a: PreValidation[T],
                               path: String = "",
                               outermostClassName: Option[String] = None,
                               config: ValidationRecordConfig = DefaultRecordConfig)
   : PostValidation[T] = {
     val ps = caseClass.parameters
-    val cs = new Array[Any](ps.length)
+    val as = new Array[ValidatorAccessor[Any]](ps.length)
     var i = 0
-    var atLeastOneValid = false
-    var atLeastOneInvalid = false
 
-    val counterClassName =
-      if (outermostClassName.isEmpty) caseClass.typeName.full else outermostClassName.get
     while (i < ps.length) {
       val p = ps(i)
       val deref = p.dereference(a.forceGet)
-      val v =
-        if (!p.typeclass.isInstanceOf[IgnoreValidator[_]]) {
-          val name = new JStringBuilder(path.length + p.label.length)
-            .append(path).append(p.label).toString
-          //TODO: This get wrapped in unvalidated seems unnecessary, how can we get rid of it
-          val o = if (
-             p.typeclass.isInstanceOf[FieldValidator[_]]
-          ) {
-            val v = p.typeclass.validateRecord(Unvalidated(deref))
-            val validationType = p.typeclass.asInstanceOf[FieldValidator[_]].validationType
-
-            val c = config.fieldConfig(name)
-            if (v.isValid) {
-              if (c != NoCounter) {
-                reporter.reportValid(
-                  counterClassName,
-                  name,
-                  validationType)
-              }
-            } else if (v.isInvalid) {
-              if (c == ThrowException) {
-                throw new DataInvalidException(
-                  s"Invalid value ${v.forceGet.toString} found for field $path${p.label}")
-              }
-              if (c != NoCounter) {
-                reporter.reportInvalid(
-                  counterClassName,
-                  name,
-                  validationType
-                )
-              }
-            }
-            v
-          } else {
-            p.typeclass.validateRecord(
-              Unvalidated(deref),
-              new JStringBuilder(path.length + p.label.length + 1)
-                .append(path).append(p.label).append(".").toString,
-              Some(counterClassName),
-              config
-            )
-          }
-
-          if (o.isValid) {
-            atLeastOneValid = true
-          }
-          else if (o.isInvalid) {
-            atLeastOneInvalid = true
-          }
-
-          o.forceGet
-        }
-        else {
-          deref
-        }
-      cs.update(i, v)
+      as.update(i, ValidatorAccessor(p.typeclass, deref, p.label)
+        .asInstanceOf[ValidatorAccessor[Any]])
       i = i + 1
     }
-
-    val record = caseClass.rawConstruct(ArraySeq.unsafeWrapArray(cs))
-
-    if (atLeastOneInvalid){
-      Invalid(record)
-    }
-    else if (atLeastOneValid) {
-      Valid(record)
-    }
-    else {
-      IgnoreValidation(record)
-    }
+    Validator.validationLoop(
+      as,
+      caseClass.rawConstruct,
+      if (outermostClassName.isEmpty) caseClass.typeName.full else outermostClassName.get,
+      path,
+      config
+    )
   }
 
   override def shouldValidate: Boolean = {
@@ -130,5 +63,4 @@ final private[elitzur] case class DerivedValidator[T] private(caseClass: CaseCla
     }
     shouldValidate
   }
-  //scalastyle:on method.length cyclomatic.complexity
 }

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/DerivedValidator.scala
@@ -33,6 +33,7 @@ final private[elitzur] case class DerivedValidator[T] private(caseClass: CaseCla
     val as = new Array[ValidatorAccessor[Any]](ps.length)
     var i = 0
 
+    // Loop through parameters once to dereference and avoid leaking magnolia types in APIs
     while (i < ps.length) {
       val p = ps(i)
       val deref = p.dereference(a.forceGet)

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
@@ -264,7 +264,6 @@ object Validator extends Serializable {
     var i = 0
     var atLeastOneValid = false
     var atLeastOneInvalid = false
-    val counterClassName = outermostClassName
 
     while (i < validatorAccessors.length) {
       val accessor = validatorAccessors(i)
@@ -280,7 +279,7 @@ object Validator extends Serializable {
             if (v.isValid) {
               if (c != NoCounter) {
                 reporter.reportValid(
-                  counterClassName,
+                  outermostClassName,
                   name,
                   validationType
                 )
@@ -292,7 +291,7 @@ object Validator extends Serializable {
               }
               if (c != NoCounter) {
                 reporter.reportInvalid(
-                  counterClassName,
+                  outermostClassName,
                   name,
                   validationType
                 )
@@ -304,7 +303,7 @@ object Validator extends Serializable {
               Unvalidated(accessor.value),
               new JStringBuilder(path.length + accessor.label.length + 1)
                 .append(path).append(accessor.label).append(".").toString,
-              Some(counterClassName),
+              Some(outermostClassName),
               config
             )
           }

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
@@ -247,8 +247,7 @@ object Validator extends Serializable {
     override def shouldValidate: Boolean = true
   }
 
-  //TODO: fix scalastyle
-  //scalastyle:off
+  //scalastyle:off method.length cyclomatic.complexity
   /**
    * Core validation loop for both dynamic and derived validators
    * This code is deliberately mutable, uses casts to avoid unboxing, and avoids dereferencing
@@ -335,7 +334,7 @@ object Validator extends Serializable {
       IgnoreValidation(record)
     }
   }
-  //scalastyle:on
+  //scalastyle:on method.length cyclomatic.complexity
 
   def fallback[T]: Validator[T] = macro ValidatorMacros.issueFallbackWarning[T]
 

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/ValidatorAccessor.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/ValidatorAccessor.scala
@@ -1,0 +1,3 @@
+package com.spotify.elitzur.validators
+
+case class ValidatorAccessor[T](validator: Validator[T], value: T, label: String)


### PR DESCRIPTION
This is to prepare support for validating dynamically

Did some minor benchmarking, perf wise it looks comparable, even on dataflow so don't see a clear need to do more extensive benchmarking.