### PR TITLE
Unwrap seq fields in getValidationTypeFromCaseClass

### DIFF
--- a/elitzur-scio/src/main/scala/com/spotify/elitzur/scio/ElitzurMetrics.scala
+++ b/elitzur-scio/src/main/scala/com/spotify/elitzur/scio/ElitzurMetrics.scala
@@ -103,17 +103,18 @@ object ElitzurMetrics {
 
     val isOption = classOf[Option[_]].equals(firstFieldClass)
     val isWrapped = classOf[ValidationStatus[_]].isAssignableFrom(firstFieldClass)
+    val isSeq = classOf[Seq[_]].isAssignableFrom(firstFieldClass)
 
     fieldNames match {
       case Seq(_) if isWrapped =>
         unwrapValidationStatus(firstFieldGenericType)
-      case Seq(_) if isOption =>
+      case Seq(_) if isOption || isSeq =>
         // remove one layer of parameterization only
         getParameterizedInnerType(firstFieldGenericType).asInstanceOf[Class[_]]
       case Seq(_) =>
         // no parameterization
         firstFieldClass
-      case Seq(_, tail@_*) if isOption =>
+      case Seq(_, tail@_*) if isOption || isSeq =>
         getValidationTypeFromCaseClass(unwrapOptionType(firstFieldGenericType), tail)
       case Seq(_, tail@_*) if isWrapped =>
         getValidationTypeFromCaseClass(unwrapValidationStatus(firstFieldGenericType), tail)

--- a/elitzur-scio/src/test/scala/com/spotify/elitzur/scio/ElitzurMetricsTest.scala
+++ b/elitzur-scio/src/test/scala/com/spotify/elitzur/scio/ElitzurMetricsTest.scala
@@ -17,6 +17,7 @@
 package com.spotify.elitzur.scio
 
 import com.spotify.elitzur.CountryCodeTesting
+import com.spotify.elitzur.scio.ElitzurMetrics.getValidationTypeFromCaseClass
 import com.spotify.elitzur.validators.ValidationStatus
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -40,6 +41,8 @@ class ElitzurMetricsTest extends AnyFlatSpec with PrivateMethodTester with Match
 
   case class HasMixedWrapping(outer: ValidationStatus[HasWrappedValidationTypes],
                               outerOption: ValidationStatus[Option[HasValidationTypes]])
+
+  case class RepeatedTest(repeated: List[CountryCodeTesting], nested: List[HasValidationTypes])
 
   "getValidationTypeFromCaseClass" should "return unqualified validation type name" in {
     val getValidationTypeFromCaseClass = PrivateMethod[String]('getValidationTypeFromCaseClass)
@@ -75,6 +78,18 @@ class ElitzurMetricsTest extends AnyFlatSpec with PrivateMethodTester with Match
   "getValidationTypeFromCaseClass" should
     "work for records where some inner fields are wrapped and some aren't" in {
     testGetValidationTypeFromCaseClass(classOf[HasMixedWrapping])
+  }
+
+  "getValidationTypeFromCaseClass" should "work for repeated fields" in {
+    val name = ElitzurMetrics
+      .getValidationTypeFromCaseClass(classOf[RepeatedTest], "repeated")
+    name shouldBe "CountryCodeTesting"
+  }
+
+  "getValidationTypeFromCaseClass" should "work for repeated records" in {
+    val name = ElitzurMetrics
+      .getValidationTypeFromCaseClass(classOf[RepeatedTest], "nested.inner")
+    name shouldBe "CountryCodeTesting"
   }
 }
 //scalastyle:on no.whitespace.before.left.bracket


### PR DESCRIPTION
This is causing `ValidityThreshold`s set on repeated fields to fail because it can't get the ValidationType name becuase we aren't unwrapping Seqs properly 