### PR TITLE
Fix Seq Validation

### DIFF
--- a/benchmarking/src/main/scala/com/spotify/elitzur/Benchmarking.scala
+++ b/benchmarking/src/main/scala/com/spotify/elitzur/Benchmarking.scala
@@ -125,6 +125,7 @@ object CaseClassValidators {
   val fiveNFiveVal: Validator[FiveNestedFiveFields] = genFiveNestedFive()
 }
 
+//scalastyle:off magic.number
 object Fields {
   import CaseClassesToValidate._
 

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Implicits.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Implicits.scala
@@ -16,6 +16,8 @@
  */
 package com.spotify.elitzur.validators
 
+import com.spotify.elitzur.MetricsReporter
+
 import scala.reflect.ClassTag
 
 trait Implicits {
@@ -37,10 +39,10 @@ trait Implicits {
   implicit def wrappedValidator[T: Validator]: Validator[ValidationStatus[T]] = new WrappedValidator[T]
   implicit def optionValidator[T: Validator]: Validator[Option[T]] = new OptionValidator[T]
   implicit def dynamicTypeValidator[T <: DynamicValidationType[_, _, _]: ClassTag]: DynamicValidator[T] = new DynamicValidator[T]
-  implicit def seqValidator[T: Validator: ClassTag]: Validator[Seq[T]] = wrapSeqLikeValidator(() => Seq.newBuilder[T])
-  implicit def listValidator[T: Validator: ClassTag]: Validator[List[T]] = wrapSeqLikeValidator(() => List.newBuilder[T])
-  implicit def arrayValidator[T: Validator: ClassTag]: Validator[Array[T]] = wrapSeqLikeValidator(() => Array.newBuilder[T])
-  implicit def vectorValidator[T: Validator: ClassTag]: Validator[Vector[T]] = wrapSeqLikeValidator(() => Vector.newBuilder[T])
+  implicit def seqValidator[T: Validator: ClassTag](implicit reporter: MetricsReporter): Validator[Seq[T]] = wrapSeqLikeValidator(() => Seq.newBuilder[T])
+  implicit def listValidator[T: Validator: ClassTag](implicit reporter: MetricsReporter): Validator[List[T]] = wrapSeqLikeValidator(() => List.newBuilder[T])
+  implicit def arrayValidator[T: Validator: ClassTag](implicit reporter: MetricsReporter): Validator[Array[T]] = wrapSeqLikeValidator(() => Array.newBuilder[T])
+  implicit def vectorValidator[T: Validator: ClassTag](implicit reporter: MetricsReporter): Validator[Vector[T]] = wrapSeqLikeValidator(() => Vector.newBuilder[T])
   //scalastyle:on line.size.limit
 
 }

--- a/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
+++ b/elitzur-core/src/main/scala/com/spotify/elitzur/validators/Validator.scala
@@ -19,7 +19,11 @@ package com.spotify.elitzur.validators
 import com.spotify.elitzur.validators.Validator.validateField
 
 import java.lang.{StringBuilder => JStringBuilder}
-import com.spotify.elitzur.{DataInvalidException, IllegalValidationException, MetricsReporter}
+import com.spotify.elitzur.{
+  DataInvalidException,
+  IllegalValidationException,
+  MetricsReporter
+}
 import magnolia._
 
 import scala.collection.mutable
@@ -30,11 +34,12 @@ import scala.collection.compat._
 import scala.collection.compat.immutable.ArraySeq
 
 trait Validator[A] extends Serializable {
-  def validateRecord(a: PreValidation[A],
-                     path: String = "",
-                     outermostClassName: Option[String] = None,
-                     config: ValidationRecordConfig = DefaultRecordConfig)
-  : PostValidation[A]
+  def validateRecord(
+      a: PreValidation[A],
+      path: String = "",
+      outermostClassName: Option[String] = None,
+      config: ValidationRecordConfig = DefaultRecordConfig
+  ): PostValidation[A]
 
   def shouldValidate: Boolean
 }
@@ -44,9 +49,12 @@ abstract class FieldValidator[A: ClassTag] extends Validator[A] {
 
   def validationType: String = classTag[A].runtimeClass.getSimpleName
 
-  override def validateRecord(a: PreValidation[A], path: String,
-                              outermostClassName: Option[String], config: ValidationRecordConfig)
-  : PostValidation[A] =
+  override def validateRecord(
+      a: PreValidation[A],
+      path: String,
+      outermostClassName: Option[String],
+      config: ValidationRecordConfig
+  ): PostValidation[A] =
     validate(a)
 
   override def shouldValidate: Boolean = true
@@ -55,31 +63,38 @@ abstract class FieldValidator[A: ClassTag] extends Validator[A] {
 class IgnoreValidator[T: ClassTag] extends FieldValidator[T] {
   override def validationType: String = "None"
 
-  override def validate(a: PreValidation[T]): PostValidation[T] = IgnoreValidation(a.forceGet)
+  override def validate(a: PreValidation[T]): PostValidation[T] =
+    IgnoreValidation(a.forceGet)
 
   override def shouldValidate: Boolean = false
 }
 
 private[elitzur] class StatusTypeValidator[A <: BaseValidationType[_]: FieldValidator: ClassTag]
-  extends FieldValidator[ValidationStatus[A]] {
+    extends FieldValidator[ValidationStatus[A]] {
   type WrappedType = ValidationStatus[A]
 
   override def validationType: String = classTag[A].runtimeClass.getSimpleName
 
-  override def validate(a: PreValidation[WrappedType]): PostValidation[WrappedType] =
+  override def validate(
+      a: PreValidation[WrappedType]
+  ): PostValidation[WrappedType] =
     PostValidationWrapper(
       implicitly[FieldValidator[A]]
-        .validate(a.forceGet.asInstanceOf[PreValidation[A]]))
+        .validate(a.forceGet.asInstanceOf[PreValidation[A]])
+    )
 }
 
 private[elitzur]
 class StatusOptionTypeValidator[A <: BaseValidationType[_]: FieldValidator: ClassTag]
-  extends FieldValidator[ValidationStatus[Option[A]]] with Serializable {
+    extends FieldValidator[ValidationStatus[Option[A]]]
+    with Serializable {
   type WrappedOption = ValidationStatus[Option[A]]
 
   override def validationType: String = classTag[A].runtimeClass.getSimpleName
 
-  override def validate(a: PreValidation[WrappedOption]): PostValidation[WrappedOption] = {
+  override def validate(
+      a: PreValidation[WrappedOption]
+  ): PostValidation[WrappedOption] = {
     val option = a.forceGet.forceGet
     if (option.isEmpty) {
       PostValidationWrapper(Valid(Option.empty))
@@ -88,22 +103,24 @@ class StatusOptionTypeValidator[A <: BaseValidationType[_]: FieldValidator: Clas
       PostValidationWrapper(
         implicitly[FieldValidator[A]]
           .validate(Unvalidated(a.forceGet.forceGet.get))
-          .map(Some(_)))
+          .map(Some(_))
+      )
     }
   }
 }
 
 private[elitzur] class OptionTypeValidator[A <: BaseValidationType[_]: FieldValidator: ClassTag]
-  extends FieldValidator[Option[A]] {
+    extends FieldValidator[Option[A]] {
 
   override def validationType: String = classTag[A].runtimeClass.getSimpleName
 
-  override def validate(a: PreValidation[Option[A]]): PostValidation[Option[A]] = {
+  override def validate(
+      a: PreValidation[Option[A]]
+  ): PostValidation[Option[A]] = {
     val option = a.forceGet
     if (option.isEmpty) {
       Valid(Option.empty)
-    }
-    else {
+    } else {
       implicitly[FieldValidator[A]]
         .validate(Unvalidated(option.get))
         .map(Option(_))
@@ -114,32 +131,46 @@ private[elitzur] class OptionTypeValidator[A <: BaseValidationType[_]: FieldVali
   override def shouldValidate: Boolean = true
 }
 
-private[elitzur] class WrappedValidator[T: Validator] extends Validator[ValidationStatus[T]] {
-  override def validateRecord(a: PreValidation[ValidationStatus[T]],
-                              path: String,
-                              outermostClassName: Option[String],
-                              config: ValidationRecordConfig)
-  : PostValidation[ValidationStatus[T]] =
+private[elitzur] class WrappedValidator[T: Validator]
+    extends Validator[ValidationStatus[T]] {
+  override def validateRecord(
+      a: PreValidation[ValidationStatus[T]],
+      path: String,
+      outermostClassName: Option[String],
+      config: ValidationRecordConfig
+  ): PostValidation[ValidationStatus[T]] =
     PostValidationWrapper(
       implicitly[Validator[T]]
-        .validateRecord(a.forceGet.asInstanceOf[PreValidation[T]], path, outermostClassName,
-          config))
+        .validateRecord(
+          a.forceGet.asInstanceOf[PreValidation[T]],
+          path,
+          outermostClassName,
+          config
+        )
+    )
 
   override def shouldValidate: Boolean = true
 }
 
-private[elitzur] class OptionValidator[T: Validator] extends Validator[Option[T]] {
-  override def validateRecord(a: PreValidation[Option[T]],
-                              path: String,
-                              outermostClassName: Option[String],
-                              config: ValidationRecordConfig)
-  : PostValidation[Option[T]] = {
+private[elitzur] class OptionValidator[T: Validator]
+    extends Validator[Option[T]] {
+  override def validateRecord(
+      a: PreValidation[Option[T]],
+      path: String,
+      outermostClassName: Option[String],
+      config: ValidationRecordConfig
+  ): PostValidation[Option[T]] = {
     val option = a.forceGet
     if (option.isEmpty) {
       Valid(None)
     } else {
       implicitly[Validator[T]]
-        .validateRecord(Unvalidated(a.forceGet.get), path, outermostClassName, config)
+        .validateRecord(
+          Unvalidated(a.forceGet.get),
+          path,
+          outermostClassName,
+          config
+        )
         .map(Some(_))
         .asInstanceOf[PostValidation[Option[T]]]
     }
@@ -150,22 +181,26 @@ private[elitzur] class OptionValidator[T: Validator] extends Validator[Option[T]
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
-private[elitzur]
-class SeqLikeValidator[T: ClassTag: Validator, C[_]](builderFn: () => mutable.Builder[T, C[T]])
-                                                    (implicit reporter: MetricsReporter,
-                                                     toSeq: C[T] => IterableOnce[T])
-  extends Validator[C[T]] {
-  override def validateRecord(a: PreValidation[C[T]],
-                              path: String,
-                              outermostClassName: Option[String],
-                              config: ValidationRecordConfig): PostValidation[C[T]] = {
+private[elitzur] class SeqLikeValidator[T: ClassTag: Validator, C[_]](
+    builderFn: () => mutable.Builder[T, C[T]]
+)(implicit reporter: MetricsReporter, toSeq: C[T] => IterableOnce[T])
+    extends Validator[C[T]] {
+  override def validateRecord(
+      a: PreValidation[C[T]],
+      path: String,
+      outermostClassName: Option[String],
+      config: ValidationRecordConfig
+  ): PostValidation[C[T]] = {
     // Use mutable state for perf
     var atLeastOneInvalid = false
     val v = implicitly[Validator[T]]
     val builder = builderFn()
-    val fullPath = if (v.isInstanceOf[FieldValidator[_]]) path else {
-      new JStringBuilder(path.length + 1).append(path).append(".").toString
-    }
+    val fullPath =
+      if (v.isInstanceOf[FieldValidator[_]]) {
+        path
+      } else {
+        new JStringBuilder(path.length + 1).append(path).append(".").toString
+      }
 
     toSeq(a.forceGet).iterator.foreach(ele => {
       val res = if (v.isInstanceOf[FieldValidator[_]]) {
@@ -175,7 +210,8 @@ class SeqLikeValidator[T: ClassTag: Validator, C[_]](builderFn: () => mutable.Bu
           Unvalidated(ele),
           c,
           outermostClassName.get,
-          fullPath)
+          fullPath
+        )
       } else {
         v.validateRecord(Unvalidated(ele), fullPath, outermostClassName, config)
       }
@@ -197,23 +233,29 @@ class SeqLikeValidator[T: ClassTag: Validator, C[_]](builderFn: () => mutable.Bu
 }
 
 private[elitzur] class BaseFieldValidator[A <: BaseValidationType[_]: ClassTag]
-  extends FieldValidator[A] {
+    extends FieldValidator[A] {
 
   override def validationType: String = classTag[A].runtimeClass.getSimpleName
 
   override def validate(data: PreValidation[A]): PostValidation[A] = {
-    if (data.forceGet.checkValid) Valid(data.forceGet) else Invalid(data.forceGet)
+    if (data.forceGet.checkValid) {
+      Valid(data.forceGet)
+    } else {
+      Invalid(data.forceGet)
+    }
   }
 
 }
 
 private[elitzur] class DynamicValidator[A <: DynamicValidationType[_, _, _]: ClassTag]
- extends FieldValidator[A] {
+    extends FieldValidator[A] {
   override def validationType: String = classTag[A].runtimeClass.getSimpleName
 
   override def validate(a: PreValidation[A]): PostValidation[A] = {
     if (a.forceGet.arg.isEmpty) {
-      throw new IllegalValidationException("Can't call `.validate()` on dynamic types without args")
+      throw new IllegalValidationException(
+        "Can't call `.validate()` on dynamic types without args"
+      )
     } else if (a.forceGet.checkValid) {
       Valid(a.forceGet)
     } else {
@@ -222,14 +264,13 @@ private[elitzur] class DynamicValidator[A <: DynamicValidationType[_, _, _]: Cla
   }
 }
 
-
 object Validator extends Serializable {
   type Typeclass[T] = Validator[T]
 
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  def combine[T](caseClass: CaseClass[Validator, T])
-                (implicit reporter: MetricsReporter, tag: ClassTag[T])
-  : Validator[T] = {
+  def combine[T](
+      caseClass: CaseClass[Validator, T]
+  )(implicit reporter: MetricsReporter, tag: ClassTag[T]): Validator[T] = {
     val params = caseClass.parameters
     var i = 0
     var shouldValidate = false
@@ -243,39 +284,53 @@ object Validator extends Serializable {
     if (shouldValidate) DerivedValidator(caseClass) else new IgnoreValidator[T]
   }
 
-  def dispatch[T](sealedTrait: SealedTrait[Validator, T]): Validator[T] = new Validator[T] {
-    def validateRecord(a: PreValidation[T],
-                       path: String = "",
-                       outermostClassName: Option[String] = None,
-                       config: ValidationRecordConfig = DefaultRecordConfig)
-    : PostValidation[T] = {
-      sealedTrait.subtypes.flatMap { x =>
-        // TODO: Same circular dereference/construction here
-        val y =
-          Try(x.typeclass.validateRecord(Unvalidated(x.cast(a.forceGet)), path, outermostClassName,
-            config)).toOption
-        y
-      }.headOption.getOrElse(
-        throw new Exception(
-          s"Couldn't find validator for any subtype of ${sealedTrait.typeName.full}"))
-    }
+  def dispatch[T](sealedTrait: SealedTrait[Validator, T]): Validator[T] =
+    new Validator[T] {
+      def validateRecord(
+          a: PreValidation[T],
+          path: String = "",
+          outermostClassName: Option[String] = None,
+          config: ValidationRecordConfig = DefaultRecordConfig
+      ): PostValidation[T] = {
+        sealedTrait.subtypes
+          .flatMap { x =>
+            // TODO: Same circular dereference/construction here
+            val y =
+              Try(
+                x.typeclass.validateRecord(
+                  Unvalidated(x.cast(a.forceGet)),
+                  path,
+                  outermostClassName,
+                  config
+                )
+              ).toOption
+            y
+          }
+          .headOption
+          .getOrElse(
+            throw new Exception(
+              s"Couldn't find validator for any subtype of ${sealedTrait.typeName.full}"
+            )
+          )
+      }
 
-    override def shouldValidate: Boolean = true
-  }
+      override def shouldValidate: Boolean = true
+    }
 
   //scalastyle:off method.length cyclomatic.complexity
   /**
-   * Core validation loop for both dynamic and derived validators
-   * This code is deliberately mutable, uses casts to avoid unboxing, and avoids dereferencing
-   * Ignore Validators in order to optimize speed at runtime
-   */
+    * Core validation loop for both dynamic and derived validators
+    * This code is deliberately mutable, uses casts to avoid unboxing, and avoids dereferencing
+    * Ignore Validators in order to optimize speed at runtime
+    */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  def validationLoop[T](validatorAccessors: Array[ValidatorAccessor[Any]],
-                        constructor: Seq[Any] => T,
-                        outermostClassName: String,
-                        path: String = "",
-                        config: ValidationRecordConfig = DefaultRecordConfig)
-                       (implicit reporter: MetricsReporter): PostValidation[T] = {
+  def validationLoop[T](
+      validatorAccessors: Array[ValidatorAccessor[Any]],
+      constructor: Seq[Any] => T,
+      outermostClassName: String,
+      path: String = "",
+      config: ValidationRecordConfig = DefaultRecordConfig
+  )(implicit reporter: MetricsReporter): PostValidation[T] = {
     val cs = new Array[Any](validatorAccessors.length)
     var i = 0
     var atLeastOneValid = false
@@ -285,7 +340,9 @@ object Validator extends Serializable {
       val v =
         if (!accessor.validator.isInstanceOf[IgnoreValidator[_]]) {
           val name = new JStringBuilder(path.length + accessor.label.length)
-            .append(path).append(accessor.label).toString
+            .append(path)
+            .append(accessor.label)
+            .toString
           val o = if (accessor.validator.isInstanceOf[FieldValidator[_]]) {
             val fieldConf = config.fieldConfig(name)
             validateField(
@@ -293,76 +350,84 @@ object Validator extends Serializable {
               Unvalidated(accessor.value),
               fieldConf,
               outermostClassName,
-              name)
+              name
+            )
           } else {
             // SeqLikeValidator can contain either nested records or fields we want to validate
             // we don't want to append a delimiter to leaf-field's path so we wait and branch the
             // logic within SeqLikeValidator
-            val nextPath = if (accessor.validator.isInstanceOf[SeqLikeValidator[_, Seq]]) {
-              new JStringBuilder(path.length + accessor.label.length)
-                .append(path).append(accessor.label).toString
-            } else {
-              new JStringBuilder(path.length + accessor.label.length + 1)
-                .append(path).append(accessor.label).append(".").toString
-            }
+            val nextPath =
+              if (accessor.validator.isInstanceOf[SeqLikeValidator[_, Seq]]) {
+                new JStringBuilder(path.length + accessor.label.length)
+                  .append(path)
+                  .append(accessor.label)
+                  .toString
+              } else {
+                new JStringBuilder(path.length + accessor.label.length + 1)
+                  .append(path)
+                  .append(accessor.label)
+                  .append(".")
+                  .toString
+              }
             accessor.validator.validateRecord(
               Unvalidated(accessor.value),
               nextPath,
               Some(outermostClassName),
-              config)
-            }
-
-            if (o.isValid) {
-              atLeastOneValid = true
-            } else if (o.isInvalid) {
-              atLeastOneInvalid = true
-            }
-
-            o.forceGet
-          } else {
-            accessor.value
+              config
+            )
           }
-          cs.update(i, v)
-          i = i + 1
+
+          if (o.isValid) {
+            atLeastOneValid = true
+          } else if (o.isInvalid) {
+            atLeastOneInvalid = true
+          }
+
+          o.forceGet
+        } else {
+          accessor.value
         }
-      val record = constructor(ArraySeq.unsafeWrapArray(cs))
-      if (atLeastOneInvalid){
-        Invalid(record)
-      }
-      else if (atLeastOneValid) {
-        Valid(record)
-      }
-      else {
-        IgnoreValidation(record)
-      }
+      cs.update(i, v)
+      i = i + 1
     }
+    val record = constructor(ArraySeq.unsafeWrapArray(cs))
+    if (atLeastOneInvalid) {
+      Invalid(record)
+    } else if (atLeastOneValid) {
+      Valid(record)
+    } else {
+      IgnoreValidation(record)
+    }
+  }
   //scalastyle:on method.length cyclomatic.complexity
 
   def fallback[T]: Validator[T] = macro ValidatorMacros.issueFallbackWarning[T]
 
   implicit def gen[T]: Validator[T] = macro ValidatorMacros.wrappedValidator[T]
 
-  private[validators]
-  def wrapSeqLikeValidator[T: ClassTag: Validator, C[_]](builderFn: () => mutable.Builder[T, C[T]])
-                                                        (implicit reporter: MetricsReporter,
-                                                         toSeq: C[T] => IterableOnce[T],
-                                                         ev: ClassTag[C[T]]): Validator[C[T]] = {
+  private[validators] def wrapSeqLikeValidator[T: ClassTag: Validator, C[_]](
+      builderFn: () => mutable.Builder[T, C[T]]
+  )(
+      implicit reporter: MetricsReporter,
+      toSeq: C[T] => IterableOnce[T],
+      ev: ClassTag[C[T]]
+  ): Validator[C[T]] = {
     if (implicitly[Validator[T]].shouldValidate) {
       new SeqLikeValidator[T, C](builderFn)
-    }
-    else {
+    } else {
       new IgnoreValidator[C[T]]
     }
   }
 
   // This logs metrics alongside validation. This is pulled out of the validation loop
   // because it needs to be used both on record fields and validation types in Seqs
-  def validateField[T](validator: FieldValidator[T],
-                       value: PreValidation[T],
-                       config: ValidationFieldConfig,
-                       outermostClassName: String,
-                       fieldName: String)
-                       (implicit reporter: MetricsReporter): PostValidation[T] = {
+  def validateField[T](
+      validator: FieldValidator[T],
+      value: PreValidation[T],
+      config: ValidationFieldConfig,
+      outermostClassName: String,
+      fieldName: String
+  )(implicit reporter: MetricsReporter): PostValidation[T] = {
     val result = validator.validateRecord(value)
     val validationType = validator.validationType
 
@@ -377,7 +442,8 @@ object Validator extends Serializable {
     } else if (result.isInvalid) {
       if (config == ThrowException) {
         throw new DataInvalidException(
-          s"Invalid value ${result.forceGet.toString} found for field $fieldName")
+          s"Invalid value ${result.forceGet.toString} found for field $fieldName"
+        )
       }
       if (config != NoCounter) {
         reporter.reportInvalid(

--- a/elitzur-core/src/test/scala/com/spotify/elitzur/validators/ValidatorTest.scala
+++ b/elitzur-core/src/test/scala/com/spotify/elitzur/validators/ValidatorTest.scala
@@ -21,6 +21,7 @@ case class Inner(
     countryOpt: Option[CountryCodeTesting]
 )
 
+//scalastyle:off magic.number
 class ValidatorTest extends AnyFlatSpec with Matchers {
 
   val inner = Inner(

--- a/elitzur-core/src/test/scala/com/spotify/elitzur/validators/ValidatorTest.scala
+++ b/elitzur-core/src/test/scala/com/spotify/elitzur/validators/ValidatorTest.scala
@@ -1,0 +1,62 @@
+package com.spotify.elitzur.validators
+
+import com.spotify.elitzur.{AgeTesting, CountryCodeTesting, MetricsReporter}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+case class Outer(
+    country: ValidationStatus[CountryCodeTesting],
+    innerStatus: ValidationStatus[Inner],
+    inner: Inner,
+    age: AgeTesting,
+    ageOpt: Option[AgeTesting],
+    repeatedAge: List[AgeTesting],
+    repeatedInner: List[Inner]
+)
+
+case class Inner(
+    countryStatus: ValidationStatus[CountryCodeTesting],
+    country: CountryCodeTesting,
+    countryOpt: Option[CountryCodeTesting]
+)
+
+class ValidatorTest extends AnyFlatSpec with Matchers {
+
+  val inner = Inner(
+    countryStatus = Unvalidated(CountryCodeTesting("US")),
+    country = CountryCodeTesting("CA"),
+    countryOpt = Some(CountryCodeTesting("SE"))
+  )
+
+  implicit val testMetricsReporter: MetricsReporter = new MetricsReporter {
+    override def reportValid(
+        className: String,
+        fieldName: String,
+        validationTypeName: String
+    ): Unit = ()
+
+    override def reportInvalid(
+        className: String,
+        fieldName: String,
+        validationTypeName: String
+    ): Unit = ()
+  }
+
+  "Validator" should "validate record" in {
+    val validator = Validator.gen[Outer]
+    val result = validator.validateRecord(
+      Unvalidated(
+        Outer(
+          country = Unvalidated(CountryCodeTesting("US")),
+          innerStatus = Unvalidated(inner),
+          inner = inner,
+          age = AgeTesting(25L),
+          ageOpt = Some(AgeTesting(45L)),
+          repeatedAge = List(AgeTesting(50L), AgeTesting(10L)),
+          repeatedInner = List(inner, inner, inner)
+        )
+      )
+    )
+    result.isInvalid shouldBe false
+  }
+}

--- a/elitzur-scio/src/test/scala/com/spotify/elitzur/ValidatorDoFnTest.scala
+++ b/elitzur-scio/src/test/scala/com/spotify/elitzur/ValidatorDoFnTest.scala
@@ -133,11 +133,17 @@ class ValidatorDoFnTest extends PipelineSpec {
   "Validator SCollection" should "validate collection of Seq,Vector,List or Array " +
     "and set counters" in {
     JobTest[DummyPipeline.type ]
-      .counters(_.size shouldBe 5)
+      .counters(_.size shouldBe 6)
       .counter(
         ScioMetrics.counter(
           "com.spotify.elitzur.TestClasses.SeqTest",
           "t/CountryCodeTesting/ElitzurInvalid"
+        )
+      )(_ shouldBe 2)
+      .counter(
+        ScioMetrics.counter(
+          "com.spotify.elitzur.TestClasses.SeqTest",
+          "t/CountryCodeTesting/ElitzurValid"
         )
       )(_ shouldBe 1)
       .counter(
@@ -145,25 +151,25 @@ class ValidatorDoFnTest extends PipelineSpec {
           "com.spotify.elitzur.TestClasses.ListTest",
           "t/CountryCodeTesting/ElitzurValid"
         )
-      )(_ shouldBe 1)
+      )(_ shouldBe 2)
       .counter(
         ScioMetrics.counter(
           "com.spotify.elitzur.TestClasses.ArrayTest",
           "t/CountryCodeTesting/ElitzurInvalid"
         )
-      )(_ shouldBe 1)
+      )(_ shouldBe 2)
       .counter(
         ScioMetrics.counter(
           "com.spotify.elitzur.TestClasses.VectorTest",
           "t/CountryCodeTesting/ElitzurValid"
         )
-      )(_ shouldBe 1)
+      )(_ shouldBe 2)
       .counter(
         ScioMetrics.counter(
           "com.spotify.elitzur.TestClasses.NestedRecordSequence",
           "nested.t/CountryCodeTesting/ElitzurValid"
         )
-      )(_ shouldBe 1)
+      )(_ shouldBe 2)
       .run()
   }
 }


### PR DESCRIPTION
The current approach to Seq validation fails on Seqs containing nested records when it tries to get the ValidationType name from the nested record. It needs the ValidationType name in order to publish metrics. To avoid this problem this splits the field level validation logic into its own function that writes the metrics. This can then be re-used from `DerivedValidator` and `SeqLikeValidator` against any `FieldValidator`