### PR TITLE
Move to evalutate scala reflect only once

### DIFF
--- a/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/DynamicAccessorCompanion.scala
+++ b/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/DynamicAccessorCompanion.scala
@@ -39,8 +39,6 @@ class DynamicAccessorCompanion[T: TypeTag, LT <: BaseValidationType[T]: ClassTag
   private[dynamic] val validationType: String = companion.validationType
   private def parseUnsafe(v: Any): Any = companion.parse(v.asInstanceOf[T])
 
-  // The transient lazy val is required here for lambda serialization. Details on the use of
-  // transient lazy val can be read here: https://www.lyh.me/lambda-serialization.html#.YsV9Z-zMJ6o
   @transient private lazy val preParserProcessor: Any => Any =
     typeOf[T] match {
       // String in Avro can be stored as org.apache.avro.util.Utf8 (a subclass of Charsequence)

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
@@ -16,6 +16,7 @@
  */
 package com.spotify.elitzur
 
+import com.spotify.elitzur.converters.avro.dynamic.dsl.AvroAccessorException.InvalidDynamicFieldException
 import com.spotify.elitzur.converters.avro.dynamic.dsl.AvroObjMapper
 import helpers.SampleAvroRecords._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -53,5 +54,14 @@ class AvroFieldExtractorBaseTest extends AnyFlatSpec with Matchers {
     val fn = AvroObjMapper.getAvroFun("._user_id10", testSimpleAvroRecord.getSchema)
 
     fn.combineFns(testSimpleAvroRecord) should be (testSimpleAvroRecord.get("_user_id10"))
+  }
+
+  it should "throw an exception if the field is missing" in {
+    val testSimpleAvroRecord = testAvroTypes()
+    val thrown = intercept[InvalidDynamicFieldException] {
+      AvroObjMapper.getAvroFun(".notRealField", testSimpleAvroRecord.getSchema)
+    }
+
+    thrown.getMessage should include(".notRealField not found in")
   }
 }

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
@@ -16,7 +16,7 @@
  */
 package com.spotify.elitzur
 
-import com.spotify.elitzur.converters.avro.dynamic.dsl.AvroAccessorException.InvalidDynamicFieldException
+import com.spotify.elitzur.converters.avro.dynamic.dsl.AvroAccessorException._
 import com.spotify.elitzur.converters.avro.dynamic.dsl.AvroObjMapper
 import helpers.SampleAvroRecords._
 import org.scalatest.flatspec.AnyFlatSpec


### PR DESCRIPTION
This PR makes it so that the scala-reflection is evaluated only once. This leads to a huge performance improvement.

Before this change, a sample Dataflow workload had this data:
- Current vCPUs: 12
- Total vCPU time: 1.101 vCPU hr
- Current memory: 10.8 GB
- Total memory time: 0.991 GB hr
- Current HDD PD: 75 GB
- Total HDD PD time: 6.881 GB hr
- Elapsed time: 8 min 44 sec

After this change, the improvement to the same Dataflow workload is as follows:
- Current vCPUs: 4
- Total vCPU time: 0.168 vCPU hr
- Current memory: 3.6 GB
- Total memory time: 0.151 GB hr
- Current HDD PD: 25 GB
- Total HDD PD time: 1.048 GB hr
- Elapsed time: 4 min 7 sec

Also, this PR adds a change to properly return a meaningful message if the given filed doesn't exist in the schema.