### PR TITLE
Add spotify OSS maintainer metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: elitzur
+spec:
+  type: resource
+  owner: blizzard


### PR DESCRIPTION
This PR is adding a file `catalog-info.yaml` that contains Spotify open source maintainer metadata that is used internally