### PR TITLE
Remove token logic dynamic Elitzur

### DIFF
--- a/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/dsl/AvroAccessor.scala
+++ b/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/dsl/AvroAccessor.scala
@@ -71,7 +71,7 @@ case class ArrayMapAccessor(field: String, innerOps: List[BaseAccessor])
   }
 }
 
-case class ArrayNoopAccessor(field: String, innerOps: List[BaseAccessor], flatten: Boolean)
+case class ArrayNoopAccessor(field: String, innerOps: List[BaseAccessor])
   extends ArrayBaseAccessor {
   override def fn: Any => Any = (o: Any) => IndexAccessor(field).fn(o)
 }

--- a/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/dsl/AvroAccessorException.scala
+++ b/elitzur-avro/src/main/scala/com/spotify/elitzur/converters/avro/dynamic/dsl/AvroAccessorException.scala
@@ -19,9 +19,6 @@ package com.spotify.elitzur.converters.avro.dynamic.dsl
 object AvroAccessorException {
   class InvalidDynamicFieldException(msg: String) extends Exception(msg)
 
-  final val MISSING_TOKEN =
-    "Leading '.' missing in the arg. Please prepend '.' to the arg"
-
   // TODO: Update docs on Dynamic and Magnolia based Elitzur and link it to exception below
   final val UNSUPPORTED_MAP_SCHEMA =
     "Map schema not supported. Please use Magnolia version of Elitzur."
@@ -29,9 +26,4 @@ object AvroAccessorException {
   final val INVALID_UNION_SCHEMA =
     "Union schemas containing more than one non-null schemas is not supported."
 
-  final val MISSING_ARRAY_TOKEN =
-    """
-      |Missing `[]` token for an array fields. All array fields should have `[]` token provided
-      |in the input.
-      |""".stripMargin
 }

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AccessorOpToValidatorOpTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AccessorOpToValidatorOpTest.scala
@@ -57,7 +57,7 @@ class AccessorOpToValidatorOpTest extends AnyFlatSpec with Matchers {
         List[BaseAccessor](IndexAccessor(DEFAULT_VALUE), NullableAccessor(DEFAULT_VALUE,
           List[BaseAccessor](IndexAccessor(DEFAULT_VALUE))
         )),
-      flatten = false))
+      ))
     FieldAccessor(accessors).toValidatorOp should be (List(ArrayValidatorOp, OptionValidatorOp))
   }
 

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AccessorOpToValidatorOpTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AccessorOpToValidatorOpTest.scala
@@ -56,7 +56,7 @@ class AccessorOpToValidatorOpTest extends AnyFlatSpec with Matchers {
       List[BaseAccessor](ArrayNoopAccessor(DEFAULT_VALUE,
         List[BaseAccessor](IndexAccessor(DEFAULT_VALUE), NullableAccessor(DEFAULT_VALUE,
           List[BaseAccessor](IndexAccessor(DEFAULT_VALUE))
-        )),
+        ))
       ))
     FieldAccessor(accessors).toValidatorOp should be (List(ArrayValidatorOp, OptionValidatorOp))
   }

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorArrayTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorArrayTest.scala
@@ -30,7 +30,7 @@ class AvroFieldExtractorArrayTest extends AnyFlatSpec with Matchers {
   it should "extract generic records in an array" in {
     // Input: {"innerArrayRoot": [{"userId": "one"}, {"userId": "two"}]}
     // Output: [{"userId": "one"}, {"userId": "two"}]
-    val fn = AvroObjMapper.getAvroFun(".innerArrayRoot[]", testArrayRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("innerArrayRoot", testArrayRecord.getSchema)
 
     fn.combineFns(testArrayRecord) should be (testArrayRecord.getInnerArrayRoot)
   }
@@ -38,7 +38,7 @@ class AvroFieldExtractorArrayTest extends AnyFlatSpec with Matchers {
   it should "extract a field from generic records in an array" in {
     // Input: {"innerArrayRoot": [{"userId": "one"}, {"userId": "two"}]}
     // Output: ["one", "two"]
-    val fn = AvroObjMapper.getAvroFun(".innerArrayRoot[].userId", testArrayRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("innerArrayRoot.userId", testArrayRecord.getSchema)
 
     fn.combineFns(testArrayRecord) should be (
       testArrayRecord.getInnerArrayRoot.asScala.map(_.getUserId).asJava)
@@ -51,7 +51,7 @@ class AvroFieldExtractorArrayTest extends AnyFlatSpec with Matchers {
     //    ]}
     // Output: [-1, -5]
     val fn = AvroObjMapper.getAvroFun(
-      ".innerArrayRoot[].deepNestedRecord.recordId", testArrayRecord.getSchema)
+      "innerArrayRoot.deepNestedRecord.recordId", testArrayRecord.getSchema)
 
     fn.combineFns(testArrayRecord) should be (
       testArrayRecord.getInnerArrayRoot.asScala.map(_.getDeepNestedRecord.getRecordId).asJava)
@@ -64,23 +64,10 @@ class AvroFieldExtractorArrayTest extends AnyFlatSpec with Matchers {
     //    ]}
     // Output: [1, 2, 3, 4]
     val fn = AvroObjMapper.getAvroFun(
-      ".innerArrayRoot[].innerArrayInsideRecord[]", testArrayRecord.getSchema)
+      "innerArrayRoot.innerArrayInsideRecord", testArrayRecord.getSchema)
 
     fn.combineFns(testArrayRecord) should be (
       testArrayRecord.getInnerArrayRoot.asScala.flatMap(_.getInnerArrayInsideRecord.asScala).asJava)
-  }
-
-  it should "not flatten the resulting array" in {
-    // Input: {"innerArrayRoot": [
-    //    {"innerArrayInsideRecord": [1, 2]},
-    //    {"innerArrayInsideRecord": [3, 4]}
-    //    ]}
-    // Output: [[1, 2], [3, 4]]
-    val fn = AvroObjMapper.getAvroFun(
-      ".innerArrayRoot[].innerArrayInsideRecord", testArrayRecord.getSchema)
-
-    fn.combineFns(testArrayRecord) should be(
-      testArrayRecord.getInnerArrayRoot.asScala.map(_.getInnerArrayInsideRecord).asJava)
   }
 
   it should "flatten resulting array with a nullable field in the path" in {
@@ -90,7 +77,7 @@ class AvroFieldExtractorArrayTest extends AnyFlatSpec with Matchers {
     //    ]}
     // Output: [1, 2, 3, 4]
     val fn = AvroObjMapper.getAvroFun(
-      ".innerArrayRoot[].deeperArrayNestedRecord.DeeperArray[]", testArrayRecord.getSchema)
+      "innerArrayRoot.deeperArrayNestedRecord.DeeperArray", testArrayRecord.getSchema)
 
     fn.combineFns(testArrayRecord) should be (
       testArrayRecord.getInnerArrayRoot

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorBaseTest.scala
@@ -28,21 +28,21 @@ class AvroFieldExtractorBaseTest extends AnyFlatSpec with Matchers {
 
   it should "extract a primitive at the record root level" in {
     val testSimpleAvroRecord = innerNestedSample()
-    val fn = AvroObjMapper.getAvroFun(".userId", testSimpleAvroRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("userId", testSimpleAvroRecord.getSchema)
 
     fn.combineFns(testSimpleAvroRecord) should be (testSimpleAvroRecord.getUserId)
   }
 
   it should "extract an array at the record root level" in {
     val testSimpleAvroRecord = testAvroArrayTypes
-    val fn = AvroObjMapper.getAvroFun(".arrayLongs", testSimpleAvroRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("arrayLongs", testSimpleAvroRecord.getSchema)
 
     fn.combineFns(testSimpleAvroRecord) should be (testSimpleAvroRecord.getArrayLongs)
   }
 
   it should "extract a nested record" in {
     val testSimpleAvroRecord = testAvroTypes()
-    val fn = AvroObjMapper.getAvroFun(".inner.userId", testSimpleAvroRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("inner.userId", testSimpleAvroRecord.getSchema)
 
     fn.combineFns(testSimpleAvroRecord) should be (testSimpleAvroRecord.getInner.getUserId)
   }
@@ -51,7 +51,7 @@ class AvroFieldExtractorBaseTest extends AnyFlatSpec with Matchers {
     val schema = SchemaBuilder
       .builder.record("record").fields.requiredLong("_user_id10").endRecord
     val testSimpleAvroRecord = new GenericRecordBuilder(schema).set("_user_id10", 1L).build
-    val fn = AvroObjMapper.getAvroFun("._user_id10", testSimpleAvroRecord.getSchema)
+    val fn = AvroObjMapper.getAvroFun("_user_id10", testSimpleAvroRecord.getSchema)
 
     fn.combineFns(testSimpleAvroRecord) should be (testSimpleAvroRecord.get("_user_id10"))
   }
@@ -59,9 +59,9 @@ class AvroFieldExtractorBaseTest extends AnyFlatSpec with Matchers {
   it should "throw an exception if the field is missing" in {
     val testSimpleAvroRecord = testAvroTypes()
     val thrown = intercept[InvalidDynamicFieldException] {
-      AvroObjMapper.getAvroFun(".notRealField", testSimpleAvroRecord.getSchema)
+      AvroObjMapper.getAvroFun("notRealField", testSimpleAvroRecord.getSchema)
     }
 
-    thrown.getMessage should include(".notRealField not found in")
+    thrown.getMessage should include("notRealField not found in")
   }
 }

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorUnionTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/AvroFieldExtractorUnionTest.scala
@@ -29,7 +29,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "extract a null from an Union schema type" in {
     // Input: {"optRecord": null}
     // Output: null
-    val fn = AvroObjMapper.getAvroFun(".optRecord.optString", TestAvroUnionTypes.SCHEMA$)
+    val fn = AvroObjMapper.getAvroFun("optRecord.optString", TestAvroUnionTypes.SCHEMA$)
     val testNullRecord = TestAvroUnionTypes.newBuilder().setOptRecord(null).build
 
     fn.combineFns(testNullRecord) should be (testNullRecord.getOptRecord)
@@ -38,7 +38,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "extract a null from a nested Union Avro schema type" in {
     // Input: {"optRecord": {"optString": null}}
     // Output: null
-    val fn = AvroObjMapper.getAvroFun(".optRecord.optString", TestAvroUnionTypes.SCHEMA$)
+    val fn = AvroObjMapper.getAvroFun("optRecord.optString", TestAvroUnionTypes.SCHEMA$)
     val testInnerNullRecord = TestAvroUnionTypes.newBuilder()
       .setOptRecord(
         InnerComplexType.newBuilder()
@@ -53,7 +53,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "extract a primitive from a Union Avro schema type" in {
     // Input: {"optRecord": {"optString": "abc"}}
     // Output: "abc"
-    val fn = AvroObjMapper.getAvroFun(".optRecord.optString", TestAvroUnionTypes.SCHEMA$)
+    val fn = AvroObjMapper.getAvroFun("optRecord.optString", TestAvroUnionTypes.SCHEMA$)
     val testInnerNonNullRecord = TestAvroUnionTypes.newBuilder()
       .setOptRecord(
         InnerComplexType.newBuilder()
@@ -68,7 +68,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "return null if child schema is non-nullable" in {
     // Input: {"optRecord": null}
     // Output: "null"
-    val fnNonNull = AvroObjMapper.getAvroFun(".optRecord.nonOptString", TestAvroUnionTypes.SCHEMA$)
+    val fnNonNull = AvroObjMapper.getAvroFun("optRecord.nonOptString", TestAvroUnionTypes.SCHEMA$)
     val testNullRecord = TestAvroUnionTypes.newBuilder().setOptRecord(null).build
 
     fnNonNull.combineFns(testNullRecord) should be (testNullRecord.getOptRecord)
@@ -77,7 +77,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "return the elements of an array if array is not null" in {
     // Input: {"optRecord": {"optRepeatedArray": [{"userId": "a", "countryCode": "US"}]}}
     // Output: "a"
-    val fnArrayNull = AvroObjMapper.getAvroFun(".optRecord.optRepeatedArray[].userId",
+    val fnArrayNull = AvroObjMapper.getAvroFun("optRecord.optRepeatedArray.userId",
       TestAvroUnionTypes.SCHEMA$)
     val testInnerNonNullRecord = TestAvroUnionTypes.newBuilder()
       .setOptRecord(
@@ -93,7 +93,7 @@ class AvroFieldExtractorUnionTest extends AnyFlatSpec with Matchers {
   it should "return null if array is null" in {
     // Input: {"optRecord": {"optRepeatedArray": null}}
     // Output: null
-    val fnArrayNull = AvroObjMapper.getAvroFun(".optRecord.optRepeatedArray[].userId",
+    val fnArrayNull = AvroObjMapper.getAvroFun("optRecord.optRepeatedArray.userId",
       TestAvroUnionTypes.SCHEMA$)
     val testInnerNullRecord = TestAvroUnionTypes.newBuilder()
       .setOptRecord(

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationArrayTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationArrayTest.scala
@@ -42,9 +42,9 @@ class DynamicAccessorValidationArrayTest extends AnyFlatSpec with Matchers with 
   it should "correctly validate and invalidate elements in a list (Seq)" in {
     val userInput: Array[DynamicFieldParser] = Array(
       new DynamicFieldParser(
-        ".arrayLongs:NonNegativeLong",
+        "arrayLongs:NonNegativeLong",
         new DynamicAccessorCompanion[Long, NonNegativeLong],
-        AvroObjMapper.getAvroFun(".arrayLongs", TestAvroArrayTypes.SCHEMA$)
+        AvroObjMapper.getAvroFun("arrayLongs", TestAvroArrayTypes.SCHEMA$)
       )
     )
 
@@ -54,7 +54,7 @@ class DynamicAccessorValidationArrayTest extends AnyFlatSpec with Matchers with 
     testSetUp.dynamicRecordValidator.validateRecord(validAvroRecord)
 
     val (playCountValidCount, playCountInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".arrayLongs:NonNegativeLong", NonNegativeLongCompanion)
+      "arrayLongs:NonNegativeLong", NonNegativeLongCompanion)
 
     val (expectedValid, expectedInvalid) = validAvroRecord
       .getArrayLongs
@@ -69,9 +69,9 @@ class DynamicAccessorValidationArrayTest extends AnyFlatSpec with Matchers with 
   it should "correctly validate and invalidate nullable elements in a list (Seq.Option)" in {
     val userInput: Array[DynamicFieldParser] = Array(
       new DynamicFieldParser(
-        ".arrayNullableStrings:CountryCode",
+        "arrayNullableStrings:CountryCode",
         new DynamicAccessorCompanion[String, CountryCode],
-        AvroObjMapper.getAvroFun(".arrayNullableStrings", TestAvroArrayTypes.SCHEMA$)
+        AvroObjMapper.getAvroFun("arrayNullableStrings", TestAvroArrayTypes.SCHEMA$)
       )
     )
 
@@ -86,7 +86,7 @@ class DynamicAccessorValidationArrayTest extends AnyFlatSpec with Matchers with 
     testSetUp.dynamicRecordValidator.validateRecord(validAvroRecord)
 
     val (countryCountValidCount, countryCountInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".arrayNullableStrings:CountryCode", CountryCompanion)
+      "arrayNullableStrings:CountryCode", CountryCompanion)
 
     (countryCountValidCount, countryCountInvalidCount) should be((2, 1))
   }

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationBaseTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationBaseTest.scala
@@ -38,14 +38,14 @@ class DynamicAccessorValidationBaseTest extends AnyFlatSpec with Matchers with B
 
   val userInput: Array[DynamicFieldParser] = Array(
     new DynamicFieldParser(
-      ".inner.playCount:NonNegativeLong",
+      "inner.playCount:NonNegativeLong",
       new DynamicAccessorCompanion[Long, NonNegativeLong],
-      AvroObjMapper.getAvroFun(".inner.playCount", TestAvroTypes.SCHEMA$)
+      AvroObjMapper.getAvroFun("inner.playCount", TestAvroTypes.SCHEMA$)
     ),
     new DynamicFieldParser(
-      ".inner.countryCode:CountryCode",
+      "inner.countryCode:CountryCode",
       new DynamicAccessorCompanion[String, CountryCode],
-      AvroObjMapper.getAvroFun(".inner.countryCode", TestAvroTypes.SCHEMA$)
+      AvroObjMapper.getAvroFun("inner.countryCode", TestAvroTypes.SCHEMA$)
     )
   )
 
@@ -58,10 +58,10 @@ class DynamicAccessorValidationBaseTest extends AnyFlatSpec with Matchers with B
     testSetUp.dynamicRecordValidator.validateRecord(validAvroRecord)
 
     val (playCountValidCount, playCountInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".inner.playCount:NonNegativeLong", NonNegativeLongCompanion)
+      "inner.playCount:NonNegativeLong", NonNegativeLongCompanion)
 
     val (countryCodValidCount, countryCodInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".inner.countryCode:CountryCode", CountryCompanion)
+      "inner.countryCode:CountryCode", CountryCompanion)
 
     (playCountValidCount, playCountInvalidCount,
       countryCodValidCount, countryCodInvalidCount) should be ((1, 0, 1, 0))
@@ -72,16 +72,16 @@ class DynamicAccessorValidationBaseTest extends AnyFlatSpec with Matchers with B
 
     val validAvroRecord = helpers.SampleAvroRecords.testAvroTypes(isValid = false)
 
-    val abc = AvroObjMapper.getAvroFun(".inner.playCount", TestAvroTypes.SCHEMA$)
+    val abc = AvroObjMapper.getAvroFun("inner.playCount", TestAvroTypes.SCHEMA$)
 
     // Validate the sample input
     testSetUp.dynamicRecordValidator.validateRecord(validAvroRecord)
 
     val (playCountValidCount, playCountInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".inner.playCount:NonNegativeLong", NonNegativeLongCompanion)
+      "inner.playCount:NonNegativeLong", NonNegativeLongCompanion)
 
     val (countryCodValidCount, countryCodInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".inner.countryCode:CountryCode", CountryCompanion)
+      "inner.countryCode:CountryCode", CountryCompanion)
 
     (playCountValidCount, playCountInvalidCount,
       countryCodValidCount, countryCodInvalidCount) should be ((0, 1, 0, 1))

--- a/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationUnionTest.scala
+++ b/elitzur-avro/src/test/scala/com/spotify/elitzur/DynamicAccessorValidationUnionTest.scala
@@ -41,9 +41,9 @@ class DynamicAccessorValidationUnionTest extends AnyFlatSpec with Matchers with 
 
   val userInput: Array[DynamicFieldParser] = Array(
     new DynamicFieldParser(
-      ".optRecord.optString:CountryCode",
+      "optRecord.optString:CountryCode",
       new DynamicAccessorCompanion[String, CountryCode],
-      AvroObjMapper.getAvroFun(".optRecord.optString", TestAvroUnionTypes.SCHEMA$)
+      AvroObjMapper.getAvroFun("optRecord.optString", TestAvroUnionTypes.SCHEMA$)
     )
   )
 
@@ -60,7 +60,7 @@ class DynamicAccessorValidationUnionTest extends AnyFlatSpec with Matchers with 
     testSetUp.dynamicRecordValidator.validateRecord(validAvroRecord)
 
     val (countryCodValidCount, countryCodInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".optRecord.optString:CountryCode", CountryCompanion)
+      "optRecord.optString:CountryCode", CountryCompanion)
 
     (countryCodValidCount, countryCodInvalidCount) should be ((1, 0))
   }
@@ -79,7 +79,7 @@ class DynamicAccessorValidationUnionTest extends AnyFlatSpec with Matchers with 
     testSetUp.dynamicRecordValidator.validateRecord(inValidAvroRecord)
 
     val (countryCodValidCount, countryCodInvalidCount) = testSetUp.getValidAndInvalidCounts(
-      ".optRecord.optString:CountryCode", CountryCompanion)
+      "optRecord.optString:CountryCode", CountryCompanion)
 
     (countryCodValidCount, countryCodInvalidCount) should be ((1, 0))
   }


### PR DESCRIPTION
Remove the token logic from dynamic Elitzur. This means that '?', '[]' and leading '.' will not be used in specifying the path to a field. This is a non-backwards compatible change.